### PR TITLE
Fix: Language identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ composer require --dev pepakriz/phpstan-exception-rules
 
 And include and configure extension.neon in your project's PHPStan config:
 
-```yaml
+```neon
 includes:
 	- vendor/pepakriz/phpstan-exception-rules/extension.neon
 


### PR DESCRIPTION
This PR

- [x] fixes a language identifier in `README.md`

### Before

<img width="903" alt="screen shot 2018-07-15 at 11 00 14" src="https://user-images.githubusercontent.com/605483/42732255-4f05014c-881e-11e8-972c-140cfd6c6747.png">

### After

<img width="906" alt="screen shot 2018-07-15 at 11 00 01" src="https://user-images.githubusercontent.com/605483/42732256-5300d23a-881e-11e8-8d1f-29bbf930c92c.png">

