### PR TITLE
Add support for ReflectionObject and fix ReflectionZendExtension logic

### DIFF
--- a/tests/src/Rules/data/throws-php-internal-functions.php
+++ b/tests/src/Rules/data/throws-php-internal-functions.php
@@ -29,6 +29,8 @@ class Example
 
 	public function testReflection(): void
 	{
+        new \ReflectionObject(new \stdClass());
+
 		new ReflectionClass(self::class);
 		new ReflectionClass('undefinedClass'); // error: Missing @throws ReflectionException annotation
 
@@ -40,6 +42,7 @@ class Example
 		new ReflectionFunction('count');
 		new ReflectionFunction('undefinedFunction'); // error: Missing @throws ReflectionException annotation
 
+		new ReflectionZendExtension('json');
 		new ReflectionZendExtension('unknownZendExtension'); // error: Missing @throws ReflectionException annotation
 
 		new ReflectionClass(rand(0, 1) === 0 ? self::class : Throwable::class);

--- a/tests/src/Rules/data/throws-php-internal-functions.php
+++ b/tests/src/Rules/data/throws-php-internal-functions.php
@@ -6,8 +6,10 @@ use DateTime;
 use DateTimeImmutable;
 use ReflectionClass;
 use ReflectionFunction;
+use ReflectionObject;
 use ReflectionProperty;
 use ReflectionZendExtension;
+use stdClass;
 use Throwable;
 use function rand;
 
@@ -29,7 +31,7 @@ class Example
 
 	public function testReflection(): void
 	{
-        new \ReflectionObject(new \stdClass());
+		new ReflectionObject(new stdClass());
 
 		new ReflectionClass(self::class);
 		new ReflectionClass('undefinedClass'); // error: Missing @throws ReflectionException annotation


### PR DESCRIPTION
This PR prevents reporting missing throws annotation for `ReflectionObject` and fix the logic for checking exception thrown by `ReflectionZendExtension`. It also includes tests that cover both cases.