### PR TITLE
Add support for ignoring descriptive exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This extension provides following rules and features:
 	* JsonSerializable interface combinated with `json_encode()` function ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/json-serializable.php))
 * Ignore caught checked exceptions ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/try-catch.php))
 * Unnecessary `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-throws.php))
+* Optionally ignore descriptive `@throws` annotations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-descriptive-throws.php))
 * `@throws` annotation variance validation ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/throws-inheritance.php))
 * [Dynamic throw types based on arguments](#extensibility)
 * Unreachable catch statements
@@ -45,6 +46,7 @@ includes:
 parameters:
 	exceptionRules:
 		reportUnusedCatchesOfUncheckedExceptions: false
+		ignoreDescriptiveUncheckedExceptions: false
 		checkedExceptions:
 			- RuntimeException
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -1,6 +1,7 @@
 parameters:
 	exceptionRules:
 		reportUnusedCatchesOfUncheckedExceptions: false
+		ignoreDescriptiveUncheckedExceptions: false
 		checkedExceptions: []
 		uncheckedExceptions: []
 		methodThrowTypeDeclarations: []
@@ -10,6 +11,8 @@ extensions:
 	exceptionRules: Pepakriz\PHPStanExceptionRules\DI\ExceptionRulesExtension
 
 services:
+	-
+		class: Pepakriz\PHPStanExceptionRules\ThrowsAnnotationReader
 	-
 		class: Pepakriz\PHPStanExceptionRules\CheckedExceptionService(%exceptionRules.checkedExceptions%, %exceptionRules.uncheckedExceptions%)
 
@@ -43,6 +46,7 @@ services:
 		class: Pepakriz\PHPStanExceptionRules\Rules\ThrowsPhpDocRule
 		arguments:
 			reportUnusedCatchesOfUncheckedExceptions: %exceptionRules.reportUnusedCatchesOfUncheckedExceptions%
+			ignoreDescriptiveUncheckedExceptions: %exceptionRules.ignoreDescriptiveUncheckedExceptions%
 		tags: [phpstan.rules.rule]
 
 	-

--- a/src/ThrowsAnnotationReader.php
+++ b/src/ThrowsAnnotationReader.php
@@ -1,0 +1,178 @@
+<?php declare(strict_types = 1);
+
+namespace Pepakriz\PHPStanExceptionRules;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PHPStan\Analyser\NameScope;
+use PHPStan\Parser\Parser;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use ReflectionFunctionAbstract;
+use ReflectionMethod;
+use function sprintf;
+use function strtolower;
+
+/**
+ * @internal
+ */
+class ThrowsAnnotationReader
+{
+
+	/** @var Parser */
+	private $phpParser;
+
+	/** @var Lexer */
+	private $phpDocLexer;
+
+	/** @var PhpDocParser */
+	private $phpDocParser;
+
+	/** @var string[][][] */
+	private $annotations = [];
+
+	/** @var string[][][] */
+	private $uses = [];
+
+	public function __construct(Parser $phpParser, Lexer $phpDocLexer, PhpDocParser $phpDocParser)
+	{
+		$this->phpParser = $phpParser;
+		$this->phpDocLexer = $phpDocLexer;
+		$this->phpDocParser = $phpDocParser;
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	public function read(ReflectionFunctionAbstract $reflection): array
+	{
+		$functionName = $reflection->getName();
+
+		if (!isset($this->annotations[$functionName])) {
+			$this->annotations[$functionName] = $this->parse($reflection);
+		}
+
+		return $this->annotations[$functionName];
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	private function parse(ReflectionFunctionAbstract $reflection): array
+	{
+		$docComment = $reflection->getDocComment();
+
+		if ($docComment === false) {
+			return [];
+		}
+
+		$tokens = new TokenIterator($this->phpDocLexer->tokenize($docComment));
+		$phpDocNode = $this->phpDocParser->parse($tokens);
+		$nameScope = $this->createNameScope($reflection);
+
+		$annotations = [];
+		foreach ($phpDocNode->getThrowsTagValues() as $tagValue) {
+			$type = $nameScope->resolveStringName((string) $tagValue->type);
+
+			if (!isset($annotations[$type])) {
+				$annotations[$type] = [];
+			}
+
+			$annotations[$type][] = $tagValue->description;
+		}
+
+		return $annotations;
+	}
+
+	private function createNameScope(ReflectionFunctionAbstract $reflection): NameScope
+	{
+		$namespace = $reflection instanceof ReflectionMethod ?
+			$reflection->getDeclaringClass()->getNamespaceName() :
+			$reflection->getNamespaceName();
+
+		/** @var string $fileName */
+		$fileName = $reflection->getFileName();
+		$usesMap = $this->getUsesMap($fileName, $namespace);
+
+		return new NameScope($namespace, $usesMap);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getUsesMap(string $fileName, string $namespace): array
+	{
+		if (!isset($this->uses[$fileName])) {
+			$this->uses[$fileName] = $this->createUsesMap($fileName);
+		}
+
+		return $this->uses[$fileName][$namespace] ?? [];
+	}
+
+	/**
+	 * @return string[][]
+	 */
+	private function createUsesMap(string $fileName): array
+	{
+		$visitor = new class extends NodeVisitorAbstract {
+
+			/** @var string[][] */
+			public $uses = [];
+
+			/** @var string */
+			private $namespace = '';
+
+			public function enterNode(Node $node): ?Node
+			{
+				if ($node instanceof Node\Stmt\Namespace_) {
+					$this->namespace = (string) $node->name;
+
+					return null;
+				}
+
+				if ($node instanceof Node\Stmt\Use_ && $node->type === Node\Stmt\Use_::TYPE_NORMAL) {
+					foreach ($node->uses as $use) {
+						$this->addUse($use->getAlias()->name, (string) $use->name);
+					}
+
+					return null;
+				}
+
+				if ($node instanceof Node\Stmt\GroupUse) {
+					$prefix = (string) $node->prefix;
+
+					foreach ($node->uses as $use) {
+						if ($node->type !== Node\Stmt\Use_::TYPE_NORMAL && $use->type !== Node\Stmt\Use_::TYPE_NORMAL) {
+							continue;
+						}
+
+						$this->addUse($use->getAlias()->name, sprintf('%s\\%s', $prefix, (string) $use->name));
+					}
+
+					return null;
+				}
+
+				return null;
+			}
+
+			private function addUse(string $alias, string $className): void
+			{
+				if (!isset($this->uses[$this->namespace])) {
+					$this->uses[$this->namespace] = [];
+				}
+
+				$this->uses[$this->namespace][strtolower($alias)] = $className;
+			}
+
+		};
+
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor($visitor);
+		$traverser->traverse($this->phpParser->parseFile($fileName));
+
+		return $visitor->uses;
+	}
+
+}

--- a/tests/src/RuleTestCase.php
+++ b/tests/src/RuleTestCase.php
@@ -17,6 +17,8 @@ use PHPStan\File\RelativePathHelper;
 use PHPStan\PhpDoc\PhpDocStringResolver;
 use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\Rules\Registry;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\TestCase;
@@ -48,6 +50,15 @@ abstract class RuleTestCase extends TestCase
 			$this->createBroker(),
 			$this->getMethodTypeSpecifyingExtensions(),
 			$this->getStaticMethodTypeSpecifyingExtensions()
+		);
+	}
+
+	protected function createThrowsAnnotationReader(): ThrowsAnnotationReader
+	{
+		return new ThrowsAnnotationReader(
+			$this->getParser(),
+			self::getContainer()->getByType(Lexer::class),
+			self::getContainer()->getByType(PhpDocParser::class)
 		);
 	}
 

--- a/tests/src/Rules/PhpInternalsTest.php
+++ b/tests/src/Rules/PhpInternalsTest.php
@@ -36,7 +36,9 @@ class PhpInternalsTest extends RuleTestCase
 					$jsonEncodeDecodeExtension,
 				]
 			),
+			$this->createThrowsAnnotationReader(),
 			$this->createBroker(),
+			true,
 			true
 		);
 	}

--- a/tests/src/Rules/ThrowsPhpDocRuleTest.php
+++ b/tests/src/Rules/ThrowsPhpDocRuleTest.php
@@ -22,6 +22,11 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	 */
 	private $reportUnusedCatchesOfUncheckedExceptions = false;
 
+	/**
+	 * @var bool
+	 */
+	private $ignoreDescriptiveUncheckedExceptions = false;
+
 	protected function getRule(): Rule
 	{
 		$extensions = [
@@ -51,8 +56,10 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 				$extensions,
 				$extensions
 			),
+			$this->createThrowsAnnotationReader(),
 			$this->createBroker(),
-			$this->reportUnusedCatchesOfUncheckedExceptions
+			$this->reportUnusedCatchesOfUncheckedExceptions,
+			$this->ignoreDescriptiveUncheckedExceptions
 		);
 	}
 
@@ -80,6 +87,13 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	{
 		$this->reportUnusedCatchesOfUncheckedExceptions = true;
 		$this->analyse(__DIR__ . '/data/unused-catches-all.php');
+	}
+
+	public function testDescriptiveUnusedCatches(): void
+	{
+		$this->reportUnusedCatchesOfUncheckedExceptions = true;
+		$this->ignoreDescriptiveUncheckedExceptions = true;
+		$this->analyse(__DIR__ . '/data/unused-descriptive-throws.php');
 	}
 
 	public function testIterators(): void

--- a/tests/src/Rules/data/unused-descriptive-throws.php
+++ b/tests/src/Rules/data/unused-descriptive-throws.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types = 1);
+
+namespace Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows;
+
+use LogicException;
+use LogicException as LogicExceptionAlias;
+use RuntimeException;
+use RuntimeException as RuntimeExceptionAlias;
+
+class FooException extends RuntimeException {}
+class BarException extends RuntimeException {}
+
+/**
+ * @throws RuntimeException
+ * @throws RuntimeException Description.
+ */
+function unusedAnnotation() { // error: Unused @throws RuntimeException annotation
+}
+
+/**
+ * @throws RuntimeExceptionAlias
+ * @throws RuntimeException Description.
+ */
+function unusedAnnotationAlias() { // error: Unused @throws RuntimeException annotation
+}
+
+/**
+ * @throws FooException
+ * @throws BarException Description
+ */
+function unusedDescriptiveAnnotation(): void // error: Unused @throws Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows\BarException annotation
+{
+	throwFooExceptions();
+}
+
+/**
+ * @throws FooException
+ */
+function throwFooExceptions(): void
+{
+	throw new FooException();
+}
+
+/**
+ * @throws LogicException Description.
+ */
+function descriptiveAnnotation(): void
+{
+	throw new LogicException();
+}
+
+/**
+ * @throws LogicExceptionAlias Description.
+ */
+function descriptiveAnnotationAlias(): void
+{
+	throw new LogicException();
+}
+
+class UnusedThrows
+{
+
+	/**
+	 * @throws RuntimeException
+	 * @throws RuntimeException Description.
+	 */
+	public function correctAnnotation(): void
+	{
+		throw new RuntimeException();
+	}
+
+	/**
+	 * @throws RuntimeException
+	 */
+	public function unusedAnnotation(): void // error: Unused @throws RuntimeException annotation
+	{
+
+	}
+
+	/**
+	 * @throws RuntimeExceptionAlias
+	 * @throws RuntimeException Description.
+	 */
+	public function unusedAnnotationAlias(): void // error: Unused @throws RuntimeException annotation
+	{
+
+	}
+
+	/**
+	 * @throws FooException
+	 */
+	private function throwFooExceptions(): void
+	{
+		throw new FooException();
+	}
+
+	/**
+	 * @throws FooException
+	 * @throws BarException
+	 */
+	public function unusedBarAnnotation(): void // error: Unused @throws Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows\BarException annotation
+	{
+		$this->throwFooExceptions();
+	}
+
+/**
+ * @throws FooException
+ * @throws BarException Description
+ */
+public function unusedDescriptiveAnnotation(): void // error: Unused @throws Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows\BarException annotation
+{
+	$this->throwFooExceptions();
+}
+
+	/**
+	 * @throws LogicException Description.
+	 */
+	public function descriptiveAnnotation(): void
+	{
+		throw new LogicException();
+	}
+
+	/**
+	 * @throws LogicExceptionAlias Description.
+	 */
+	public function descriptiveAnnotationAlias(): void
+	{
+		throw new LogicException();
+	}
+
+	/**
+	 * @throws LogicException
+	 */
+	public function unusedLogic(): void // error: Unused @throws LogicException annotation
+	{
+		throw new LogicException();
+	}
+
+}


### PR DESCRIPTION
This PR add supports for [ignoring descriptive exceptions](https://github.com/pepakriz/phpstan-exception-rules/issues/47) in a backwards compatible manner.

A descriptive exception tag is defined as any annotation `@throws` with a non-empty description.
Tags without descriptions are treated as unused, regardless the presence of other tags with non-empty descriptions:
```php
/**
 * @throws LogicException
 * @throws LogicException Description.
 */
function unusedAnnotation(): void // Unused @throws LogicException annotation
{
    throws new \LogicException():
}
```
This implementation decouples the logic for reading annotations, tagged as `@internal`,  so that it can be easily replaced or deprecated as soon as [PHPStan provides access to the description of `@throws` annotations](https://github.com/phpstan/phpstan/issues/1868).