### PR TITLE
Check unused `@throws` annotations on functions

### DIFF
--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -370,13 +370,13 @@ class ThrowsPhpDocRule implements Rule
 		$usedThrowsAnnotations = $this->throwsScope->exitFromThrowsAnnotationBlock();
 		$usedThrowsAnnotations = $this->checkedExceptionService->filterCheckedExceptions($usedThrowsAnnotations);
 
-		$classReflection = $scope->getClassReflection();
 		$methodReflection = $scope->getFunction();
-		if ($classReflection === null || $methodReflection === null) {
+		if ($methodReflection === null) {
 			return [];
 		}
 
-		if ($classReflection->isInterface() || $classReflection->isAbstract()) {
+		$classReflection = $scope->getClassReflection();
+		if ($classReflection !== null && ($classReflection->isInterface() || $classReflection->isAbstract())) {
 			return [];
 		}
 

--- a/tests/src/Rules/data/unused-throws.php
+++ b/tests/src/Rules/data/unused-throws.php
@@ -8,6 +8,13 @@ use RuntimeException;
 class FooException extends RuntimeException {}
 class BarException extends RuntimeException {}
 
+/**
+ * @throws RuntimeException
+ */
+function foo() { // error: Unused @throws RuntimeException annotation
+
+}
+
 class UnusedThrows
 {
 


### PR DESCRIPTION
Cherry-picked from https://github.com/pepakriz/phpstan-exception-rules/pull/54