### PR TITLE
Add support for detecting exceptions thrown by magic methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This extension provides following rules and features:
 
 * Require `@throws` annotation when some checked exception is thrown ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/throws-annotations.php))
 * Exception propagation over:
-	* function calls
-	* dynamic and static method calls
+	* Function calls
+	* Magic, dynamic and static method calls
 	* Iterable interface in foreach and in `iterator_*()` functions ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/iterators.php))
 	* Countable interface combinated with `count()` function ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/countables.php))
 	* JsonSerializable interface combinated with `json_encode()` function ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/json-serializable.php))

--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -216,7 +216,11 @@ class ThrowsPhpDocRule implements Rule
 			try {
 				$targetMethodReflection = $targetClassReflection->getMethod($methodName->toString(), $scope);
 			} catch (MissingMethodFromReflectionException $e) {
-				continue;
+				try {
+					$targetMethodReflection = $targetClassReflection->getMethod('__call', $scope);
+				} catch (MissingMethodFromReflectionException $e) {
+					continue;
+				}
 			}
 
 			$throwType = $this->dynamicThrowTypeService->getMethodThrowType($targetMethodReflection, $node, $scope);

--- a/tests/src/Rules/data/throws-annotations.php
+++ b/tests/src/Rules/data/throws-annotations.php
@@ -21,6 +21,19 @@ function foo()  {
 	throw new RuntimeException();
 }
 
+class MagicService
+{
+
+	/**
+	 * @throws CheckedException
+	 */
+	public function __call($name, $arguments): void
+	{
+		throw new CheckedException();
+	}
+
+}
+
 class ThrowsAnnotationsClass
 {
 
@@ -162,6 +175,11 @@ class ThrowsAnnotationsClass
 		/** @var UnionOne|UnknownClass $union */
 		$union = getStaticUnion();
 		$union::staticFoo(); // error: Missing @throws Pepakriz\PHPStanExceptionRules\Rules\Data\SomeRuntimeException annotation
+	}
+
+	public function callMagicMethod(): void
+	{
+		(new MagicService())->foo(); // error: Missing @throws Pepakriz\PHPStanExceptionRules\Rules\Data\CheckedException annotation
 	}
 
 }


### PR DESCRIPTION
This PR add supports for detecting exceptions thrown by magic methods, for example:
```php
class MagicService
{
	/**
	 * @throws CheckedException
	 */
	public function __call($name, $arguments): void
	{
		throw new CheckedException();
	}
}

(new MagicService())->foo(); // error: Missing @throws CheckedException annotation
```

It also adds a test to cover the case above and update the readme file to mention the feature.