### PR TITLE
[Hotfix] Fix crash reading annotations of anonymous classes (fix #71)

### DIFF
--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -40,8 +40,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use PHPStan\Type\VoidType;
-use ReflectionException;
-use ReflectionFunction;
 use function array_diff;
 use function array_filter;
 use function array_map;
@@ -477,23 +475,11 @@ class ThrowsPhpDocRule implements Rule
 
 		$unusedThrows = array_diff($unusedThrows, TypeUtils::getDirectClassNames($defaultThrowsType));
 
-		try {
-			if ($functionReflection instanceof MethodReflection) {
-				$nativeClassReflection = $functionReflection->getDeclaringClass()->getNativeReflection();
-				$nativeFunctionReflection = $nativeClassReflection->getMethod($functionReflection->getName());
-
-			} else {
-				$nativeFunctionReflection = new ReflectionFunction($functionReflection->getName());
-			}
-		} catch (ReflectionException $exception) {
-			return $unusedThrows;
-		}
-
 		if (!$this->ignoreDescriptiveUncheckedExceptions) {
 			return $unusedThrows;
 		}
 
-		$throwsAnnotations = $this->throwsAnnotationReader->read($nativeFunctionReflection);
+		$throwsAnnotations = $this->throwsAnnotationReader->read($scope);
 
 		return array_filter($unusedThrows, static function (string $type) use ($throwsAnnotations, $usedThrowsAnnotations): bool {
 			return !in_array($type, $usedThrowsAnnotations, true)

--- a/tests/src/Rules/data/unused-descriptive-throws.php
+++ b/tests/src/Rules/data/unused-descriptive-throws.php
@@ -103,14 +103,14 @@ class UnusedThrows
 		$this->throwFooExceptions();
 	}
 
-/**
- * @throws FooException
- * @throws BarException Description
- */
-public function unusedDescriptiveAnnotation(): void // error: Unused @throws Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows\BarException annotation
-{
-	$this->throwFooExceptions();
-}
+	/**
+	 * @throws FooException
+	 * @throws BarException Description
+	 */
+	public function unusedDescriptiveAnnotation(): void // error: Unused @throws Pepakriz\PHPStanExceptionRules\Rules\UnusedDescriptiveThrows\BarException annotation
+	{
+		$this->throwFooExceptions();
+	}
 
 	/**
 	 * @throws LogicException Description.
@@ -137,3 +137,15 @@ public function unusedDescriptiveAnnotation(): void // error: Unused @throws Pep
 	}
 
 }
+
+new class {
+
+	/**
+	 * @throws RuntimeException Overridden description.
+	 */
+	public function descriptiveAnnotationAlias(): void
+	{
+		throw new RuntimeException();
+	}
+
+};


### PR DESCRIPTION
As  the `ThrowsAnnotationReader` class is `@internal`, there is no BC break.