### PR TITLE
Add support for method whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ parameters:
 				- FooException
 ```
 
+In some cases, you may want to ignore exception-related errors as per class basis, as is usually the case for testing:
+
+```neon
+parameters:
+	exceptionRules:
+		methodWhitelist:
+			PHPUnit\Framework\TestCase:
+				- '#^(setup|setupbeforeclass|teardown|teardownafterclass|test.+)$#i'
+```
+
 ## Extensibility
 
 `Dynamic throw type extensions` - If the throw type is not always the same, but depends on an argument passed to the method. (Similar feature as [Dynamic return type extensions](https://github.com/phpstan/phpstan#dynamic-return-type-extensions))

--- a/extension.neon
+++ b/extension.neon
@@ -7,6 +7,7 @@ parameters:
 		uncheckedExceptions: []
 		methodThrowTypeDeclarations: []
 		functionThrowTypeDeclarations: []
+		methodWhitelist: []
 
 parametersSchema:
 	exceptionRules: structure([
@@ -17,6 +18,7 @@ parametersSchema:
 		uncheckedExceptions: listOf(string())
 		methodThrowTypeDeclarations: arrayOf(arrayOf(listOf(string())))
 		functionThrowTypeDeclarations: arrayOf(listOf(string()))
+		methodWhitelist: arrayOf(listOf(string()))
 	])
 
 services:
@@ -71,6 +73,7 @@ services:
 			reportUnusedCatchesOfUncheckedExceptions: %exceptionRules.reportUnusedCatchesOfUncheckedExceptions%
 			reportCheckedThrowsInGlobalScope: %exceptionRules.reportCheckedThrowsInGlobalScope%
 			ignoreDescriptiveUncheckedExceptions: %exceptionRules.ignoreDescriptiveUncheckedExceptions%
+			methodWhitelist: %exceptionRules.methodWhitelist%
 		tags: [phpstan.rules.rule]
 
 	-

--- a/tests/src/Rules/PhpInternalsTest.php
+++ b/tests/src/Rules/PhpInternalsTest.php
@@ -45,7 +45,8 @@ class PhpInternalsTest extends RuleTestCase
 			$this->createBroker(),
 			true,
 			true,
-			true
+			true,
+			[]
 		);
 	}
 

--- a/tests/src/Rules/ThrowsPhpDocRuleTest.php
+++ b/tests/src/Rules/ThrowsPhpDocRuleTest.php
@@ -13,6 +13,7 @@ use Pepakriz\PHPStanExceptionRules\Rules\UnusedCatches\UnusedCatches;
 use Pepakriz\PHPStanExceptionRules\RuleTestCase;
 use PharData;
 use PHPStan\Rules\Rule;
+use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use RuntimeException;
 
@@ -33,6 +34,11 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	 * @var bool
 	 */
 	private $reportCheckedThrowsInGlobalScope = false;
+
+	/**
+	 * @var array<string, string>
+	 */
+	private $methodWhitelist = [];
 
 	/**
 	 * @var mixed[]
@@ -75,7 +81,8 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 			$this->createBroker(),
 			$this->reportUnusedCatchesOfUncheckedExceptions,
 			$this->reportCheckedThrowsInGlobalScope,
-			$this->ignoreDescriptiveUncheckedExceptions
+			$this->ignoreDescriptiveUncheckedExceptions,
+			$this->methodWhitelist
 		);
 	}
 
@@ -159,6 +166,12 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	{
 		$this->reportCheckedThrowsInGlobalScope = true;
 		$this->analyse(__DIR__ . '/data/throws-in-global-scope.php');
+	}
+
+	public function testMethodWhitelist(): void
+	{
+		$this->methodWhitelist = [TestCase::class => '/^test/'];
+		$this->analyse(__DIR__ . '/data/method-whitelisting.php');
 	}
 
 }

--- a/tests/src/Rules/data/method-whitelisting.php
+++ b/tests/src/Rules/data/method-whitelisting.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Pepakriz\PHPStanExceptionRules\Rules\Data\InheritanceOverriding;
+
+use RuntimeException;
+use PHPUnit\Framework\TestCase;
+
+class FooTest extends TestCase {
+
+	public function foo(): void
+	{
+	}
+
+	/**
+	 * @throws RuntimeException
+	 */
+	public function testBar(): void  // error: Unused @throws RuntimeException annotation
+	{
+		throw new RuntimeException();
+	}
+
+	/**
+	 * @throws RuntimeException
+	 */
+	public function bar(): void
+	{
+		throw new RuntimeException();
+	}
+
+}


### PR DESCRIPTION
Fixes #24 

A new `methodWhitelist` option allows specifying classes and patterns as key-value pairs for matching methods which does not require `@throws` annotations to be specified.