### PR TITLE
Allow intentional unused @throws in implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This extension provides following rules and features:
 * Unnecessary `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-throws.php))
 * Useless `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/useless-throws.php))
 * Optionally ignore descriptive `@throws` annotations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-descriptive-throws.php))
-* Optionally allows unused  `@throws` annotations in implementations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/intentionally-unused-throws.php))
+* Optionally allow unused  `@throws` annotations in implementations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/intentionally-unused-throws.php))
 * `@throws` annotation variance validation ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/throws-inheritance.php))
 * [Dynamic throw types based on arguments](#extensibility)
 * Unreachable catch statements

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This extension provides following rules and features:
 * Unnecessary `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-throws.php))
 * Useless `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/useless-throws.php))
 * Optionally ignore descriptive `@throws` annotations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-descriptive-throws.php))
-* Optionally allow unused  `@throws` annotations in implementations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/intentionally-unused-throws.php))
+* Optionally allows unused `@throws` annotations in implementations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/intentionally-unused-throws.php))
 * `@throws` annotation variance validation ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/throws-inheritance.php))
 * [Dynamic throw types based on arguments](#extensibility)
 * Unreachable catch statements
@@ -51,7 +51,7 @@ parameters:
 		reportUnusedCatchesOfUncheckedExceptions: false
 		reportCheckedThrowsInGlobalScope: false
 		ignoreDescriptiveUncheckedExceptions: false
-		allowImplementationUnusedThrows: false
+		allowUnusedThrowsInImplementation: false
 		checkedExceptions:
 			- RuntimeException
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This extension provides following rules and features:
 * Unnecessary `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-throws.php))
 * Useless `@throws` annotation detection ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/useless-throws.php))
 * Optionally ignore descriptive `@throws` annotations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/unused-descriptive-throws.php))
+* Optionally allows unused  `@throws` annotations in implementations ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/intentionally-unused-throws.php))
 * `@throws` annotation variance validation ([examples](https://github.com/pepakriz/phpstan-exception-rules/blob/master/tests/src/Rules/data/throws-inheritance.php))
 * [Dynamic throw types based on arguments](#extensibility)
 * Unreachable catch statements
@@ -50,6 +51,7 @@ parameters:
 		reportUnusedCatchesOfUncheckedExceptions: false
 		reportCheckedThrowsInGlobalScope: false
 		ignoreDescriptiveUncheckedExceptions: false
+		allowImplementationUnusedThrows: false
 		checkedExceptions:
 			- RuntimeException
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -3,6 +3,7 @@ parameters:
 		reportUnusedCatchesOfUncheckedExceptions: false
 		reportCheckedThrowsInGlobalScope: true
 		ignoreDescriptiveUncheckedExceptions: false
+		allowImplementationUnusedThrows: false
 		checkedExceptions: []
 		uncheckedExceptions: []
 		methodThrowTypeDeclarations: []
@@ -14,6 +15,7 @@ parametersSchema:
 		reportUnusedCatchesOfUncheckedExceptions: bool()
 		reportCheckedThrowsInGlobalScope: bool()
 		ignoreDescriptiveUncheckedExceptions: bool()
+		allowImplementationUnusedThrows: bool()
 		checkedExceptions: listOf(string())
 		uncheckedExceptions: listOf(string())
 		methodThrowTypeDeclarations: arrayOf(arrayOf(listOf(string())))
@@ -73,6 +75,7 @@ services:
 			reportUnusedCatchesOfUncheckedExceptions: %exceptionRules.reportUnusedCatchesOfUncheckedExceptions%
 			reportCheckedThrowsInGlobalScope: %exceptionRules.reportCheckedThrowsInGlobalScope%
 			ignoreDescriptiveUncheckedExceptions: %exceptionRules.ignoreDescriptiveUncheckedExceptions%
+			allowImplementationUnusedThrows: %exceptionRules.allowImplementationUnusedThrows%
 			methodWhitelist: %exceptionRules.methodWhitelist%
 		tags: [phpstan.rules.rule]
 

--- a/extension.neon
+++ b/extension.neon
@@ -3,7 +3,7 @@ parameters:
 		reportUnusedCatchesOfUncheckedExceptions: false
 		reportCheckedThrowsInGlobalScope: true
 		ignoreDescriptiveUncheckedExceptions: false
-		allowImplementationUnusedThrows: false
+		allowUnusedThrowsInImplementation: false
 		checkedExceptions: []
 		uncheckedExceptions: []
 		methodThrowTypeDeclarations: []
@@ -15,7 +15,7 @@ parametersSchema:
 		reportUnusedCatchesOfUncheckedExceptions: bool()
 		reportCheckedThrowsInGlobalScope: bool()
 		ignoreDescriptiveUncheckedExceptions: bool()
-		allowImplementationUnusedThrows: bool()
+		allowUnusedThrowsInImplementation: bool()
 		checkedExceptions: listOf(string())
 		uncheckedExceptions: listOf(string())
 		methodThrowTypeDeclarations: arrayOf(arrayOf(listOf(string())))
@@ -75,7 +75,7 @@ services:
 			reportUnusedCatchesOfUncheckedExceptions: %exceptionRules.reportUnusedCatchesOfUncheckedExceptions%
 			reportCheckedThrowsInGlobalScope: %exceptionRules.reportCheckedThrowsInGlobalScope%
 			ignoreDescriptiveUncheckedExceptions: %exceptionRules.ignoreDescriptiveUncheckedExceptions%
-			allowImplementationUnusedThrows: %exceptionRules.allowImplementationUnusedThrows%
+			allowUnusedThrowsInImplementation: %exceptionRules.allowUnusedThrowsInImplementation%
 			methodWhitelist: %exceptionRules.methodWhitelist%
 		tags: [phpstan.rules.rule]
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,9 @@ parameters:
 			- PHPUnit\Framework\Exception
 			- Nette\DI\MissingServiceException
 		methodThrowTypeDeclarations:
+			ReflectionMethod:
+				getPrototype:
+					- ReflectionException
 			PHPStan\Broker\Broker:
 				getClass:
 					- PHPStan\Broker\ClassNotFoundException

--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -109,6 +109,11 @@ class ThrowsPhpDocRule implements Rule
 	 */
 	private $ignoreDescriptiveUncheckedExceptions;
 
+	/**
+	 * @var bool
+	 */
+	private $allowImplementationUnusedThrows;
+
 	/** @var string[] */
 	private $methodWhitelist;
 
@@ -124,6 +129,7 @@ class ThrowsPhpDocRule implements Rule
 		bool $reportUnusedCatchesOfUncheckedExceptions,
 		bool $reportCheckedThrowsInGlobalScope,
 		bool $ignoreDescriptiveUncheckedExceptions,
+		bool $allowImplementationUnusedThrows,
 		array $methodWhitelist
 	)
 	{
@@ -136,6 +142,7 @@ class ThrowsPhpDocRule implements Rule
 		$this->reportUnusedCatchesOfUncheckedExceptions = $reportUnusedCatchesOfUncheckedExceptions;
 		$this->reportCheckedThrowsInGlobalScope = $reportCheckedThrowsInGlobalScope;
 		$this->ignoreDescriptiveUncheckedExceptions = $ignoreDescriptiveUncheckedExceptions;
+		$this->allowImplementationUnusedThrows = $allowImplementationUnusedThrows;
 		$this->methodWhitelist = $methodWhitelist;
 	}
 
@@ -563,6 +570,16 @@ class ThrowsPhpDocRule implements Rule
 		}
 
 		$unusedThrows = array_diff($unusedThrows, TypeUtils::getDirectClassNames($defaultThrowsType));
+
+		if ($this->allowImplementationUnusedThrows && $functionReflection instanceof MethodReflection) {
+			$declaringClass = $functionReflection->getDeclaringClass();
+			$nativeClassReflection = $declaringClass->getNativeReflection();
+			$nativeMethodReflection = $nativeClassReflection->getMethod($functionReflection->getName());
+
+			if ($nativeMethodReflection->getDocComment() === false) {
+				return [];
+			}
+		}
 
 		if (!$this->ignoreDescriptiveUncheckedExceptions) {
 			return $unusedThrows;

--- a/tests/src/Rules/PhpInternalsTest.php
+++ b/tests/src/Rules/PhpInternalsTest.php
@@ -46,6 +46,7 @@ class PhpInternalsTest extends RuleTestCase
 			true,
 			true,
 			true,
+			false,
 			[]
 		);
 	}

--- a/tests/src/Rules/ThrowsPhpDocRuleTest.php
+++ b/tests/src/Rules/ThrowsPhpDocRuleTest.php
@@ -38,7 +38,7 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	/**
 	 * @var bool
 	 */
-	private $allowImplementationUnusedThrows = false;
+	private $allowUnusedThrowsInImplementation = false;
 
 	/**
 	 * @var array<string, string>
@@ -87,7 +87,7 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 			$this->reportUnusedCatchesOfUncheckedExceptions,
 			$this->reportCheckedThrowsInGlobalScope,
 			$this->ignoreDescriptiveUncheckedExceptions,
-			$this->allowImplementationUnusedThrows,
+			$this->allowUnusedThrowsInImplementation,
 			$this->methodWhitelist
 		);
 	}
@@ -182,7 +182,7 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 
 	public function testIntentionallyUnusedThrows(): void
 	{
-		$this->allowImplementationUnusedThrows = true;
+		$this->allowUnusedThrowsInImplementation = true;
 		$this->analyse(__DIR__ . '/data/intentionally-unused-throws.php');
 	}
 

--- a/tests/src/Rules/ThrowsPhpDocRuleTest.php
+++ b/tests/src/Rules/ThrowsPhpDocRuleTest.php
@@ -36,6 +36,11 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	private $reportCheckedThrowsInGlobalScope = false;
 
 	/**
+	 * @var bool
+	 */
+	private $allowImplementationUnusedThrows = false;
+
+	/**
 	 * @var array<string, string>
 	 */
 	private $methodWhitelist = [];
@@ -82,6 +87,7 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 			$this->reportUnusedCatchesOfUncheckedExceptions,
 			$this->reportCheckedThrowsInGlobalScope,
 			$this->ignoreDescriptiveUncheckedExceptions,
+			$this->allowImplementationUnusedThrows,
 			$this->methodWhitelist
 		);
 	}
@@ -172,6 +178,12 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 	{
 		$this->methodWhitelist = [TestCase::class => '/^test/'];
 		$this->analyse(__DIR__ . '/data/method-whitelisting.php');
+	}
+
+	public function testIntentionallyUnusedThrows(): void
+	{
+		$this->allowImplementationUnusedThrows = true;
+		$this->analyse(__DIR__ . '/data/intentionally-unused-throws.php');
 	}
 
 }

--- a/tests/src/Rules/data/intentionally-unused-throws.php
+++ b/tests/src/Rules/data/intentionally-unused-throws.php
@@ -5,15 +5,68 @@ namespace Pepakriz\PHPStanExceptionRules\Rules\UselessThrows;
 use RuntimeException;
 
 interface Foo {
+
 	/**
 	 * @throws RuntimeException
 	 */
-	public function method() : void;
+	public function method(): void;
+
 }
 
-class UnusedThrows implements Foo
+class ImplementationExample implements Foo
 {
-	public function method() : void
+
+	public function method(): void
 	{
 	}
+
+}
+
+abstract class AbstractParentExample
+{
+
+	/**
+	 * @throws RuntimeException
+	 */
+	abstract public function method(): void;
+
+}
+
+class AbstractExample extends AbstractParentExample {
+
+	public function method(): void
+	{
+	}
+
+}
+
+class OverridingAbstractExample extends AbstractExample
+{
+
+	public function method(): void
+	{
+	}
+
+}
+
+class ConcreteParentExample
+{
+
+	/**
+	 * @throws RuntimeException
+	 */
+	public function method(): void
+	{
+		throw new RuntimeException();
+	}
+
+}
+
+class OverridingConcreteExample extends ConcreteParentExample
+{
+
+	public function method(): void
+	{
+	}
+
 }

--- a/tests/src/Rules/data/intentionally-unused-throws.php
+++ b/tests/src/Rules/data/intentionally-unused-throws.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Pepakriz\PHPStanExceptionRules\Rules\UselessThrows;
+
+use RuntimeException;
+
+interface Foo {
+	/**
+	 * @throws RuntimeException
+	 */
+	public function method() : void;
+}
+
+class UnusedThrows implements Foo
+{
+	public function method() : void
+	{
+	}
+}


### PR DESCRIPTION
This PR adds support for allowing unused `@throws` in implementations and fixes #17.

Implementations that do not throw all possible exceptions can narrow the set of possibilities by overriding the documentation block or declaring `@throws void`. However, there is a legitimate use case where it becomes necessary: one may want always to declare that a method might throw the exceptions stated in the prototype to make it future proof.