### PR TITLE
Handle throws void

### DIFF
--- a/src/Rules/ThrowsPhpDocInheritanceRule.php
+++ b/src/Rules/ThrowsPhpDocInheritanceRule.php
@@ -134,7 +134,7 @@ class ThrowsPhpDocInheritanceRule implements Rule
 				$parentThrowType = $methodReflection->getThrowType();
 			}
 
-			if ($parentThrowType === null) {
+			if ($parentThrowType === null || $parentThrowType instanceof VoidType) {
 				$messages[] = sprintf(
 					'PHPDoc tag @throws with type %s is not compatible with parent',
 					$throwType->describe(VerbosityLevel::typeOnly())

--- a/tests/src/Rules/data/throws-inheritance-interfaces.php
+++ b/tests/src/Rules/data/throws-inheritance-interfaces.php
@@ -24,6 +24,11 @@ interface BaseThrowsAnnotations
 
 	public function parentWithoutThrows(): void;
 
+	/**
+	 * @throws void
+	 */
+	public function parentWithThrowsVoid(): void;
+
 }
 
 interface ThrowsAnnotations extends BaseThrowsAnnotations
@@ -48,6 +53,11 @@ interface ThrowsAnnotations extends BaseThrowsAnnotations
 	 * @throws BaseException
 	 */
 	public function parentWithoutThrows(): void; // error: PHPDoc tag @throws with type Pepakriz\PHPStanExceptionRules\Rules\Data\InheritanceInterfaces\BaseException is not compatible with parent
+
+	/**
+	 * @throws BaseException
+	 */
+	public function parentWithThrowsVoid(): void; // error: PHPDoc tag @throws with type Pepakriz\PHPStanExceptionRules\Rules\Data\InheritanceInterfaces\BaseException is not compatible with parent
 
 }
 
@@ -82,6 +92,14 @@ class Implementation implements BaseThrowsAnnotations
 	 * @throws BaseException
 	 */
 	public function parentWithoutThrows(): void // error: PHPDoc tag @throws with type Pepakriz\PHPStanExceptionRules\Rules\Data\InheritanceInterfaces\BaseException is not compatible with parent
+	{
+
+	}
+
+	/**
+	 * @throws BaseException
+	 */
+	public function parentWithThrowsVoid(): void // error: PHPDoc tag @throws with type Pepakriz\PHPStanExceptionRules\Rules\Data\InheritanceInterfaces\BaseException is not compatible with parent
 	{
 
 	}


### PR DESCRIPTION
Cf https://github.com/phpstan/phpstan/issues/3350#issuecomment-635136854

```
/**
 * @throws void
 **/
```
Is a way to stay there is no exceptions thrown.

If a method with this annotation is extended, we shouldn't allow to throw something.