### PR TITLE
Add Expr Throw - PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: "Check lint"
         run: "composer run-script check:lint"
+        if: ${{ matrix.php-version == '8.0' }}
 
       - name: "Check CodeStyle"
         run: "composer run-script check:cs"

--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -195,6 +195,10 @@ class ThrowsPhpDocRule implements Rule
 			return $this->processThrow($node, $scope);
 		}
 
+		if ($node instanceof Expr\Throw_) {
+			return $this->processExprThrow($node, $scope);
+		}
+
 		if ($node instanceof MethodCall) {
 			return $this->processMethodCall($node, $scope);
 		}
@@ -309,6 +313,16 @@ class ThrowsPhpDocRule implements Rule
 	 * @return RuleError[]
 	 */
 	private function processThrow(Throw_ $node, Scope $scope): array
+	{
+		$exceptionType = $scope->getType($node->expr);
+
+		return $this->processThrowsTypes($exceptionType);
+	}
+
+	/**
+	 * @return RuleError[]
+	 */
+	private function processExprThrow(Expr\Throw_ $node, Scope $scope): array
 	{
 		$exceptionType = $scope->getType($node->expr);
 

--- a/src/Rules/ThrowsPhpDocRule.php
+++ b/src/Rules/ThrowsPhpDocRule.php
@@ -168,7 +168,7 @@ class ThrowsPhpDocRule implements Rule
 		$method = $scope->getFunction();
 		$isMethodWhitelisted = $method instanceof MethodReflection && $this->isWhitelistedMethod($method);
 		if ($node instanceof MethodReturnStatementsNode) {
-			if ($isMethodWhitelisted && $method instanceof MethodReflection) {
+			if ($isMethodWhitelisted) {
 				return $this->processWhitelistedMethod($method, $node->getStartLine());
 			}
 

--- a/tests/src/Rules/ThrowsPhpDocRuleTest.php
+++ b/tests/src/Rules/ThrowsPhpDocRuleTest.php
@@ -106,6 +106,14 @@ class ThrowsPhpDocRuleTest extends RuleTestCase
 		$this->analyseFile(__DIR__ . '/data/throws-annotations.php');
 	}
 
+	/**
+	 * @requires PHP 8.0
+	 */
+	public function testExpressionThrows(): void
+	{
+		$this->analyseFile(__DIR__ . '/data/expression-throws.php');
+	}
+
 	public function testTryCatch(): void
 	{
 		$this->analyseFile(__DIR__ . '/data/try-catch.php');

--- a/tests/src/Rules/data/expression-throws.php
+++ b/tests/src/Rules/data/expression-throws.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+namespace Pepakriz\PHPStanExceptionRules\Rules\ExpressionThrows;
+
+use RuntimeException;
+
+class FooException extends RuntimeException
+{
+	public static function create(): self
+	{
+		return new self();
+	}
+}
+
+/**
+ * @throws FooException
+ */
+function foo1() {
+	$callable = fn() => throw new FooException();
+}
+
+/**
+ * @throws FooException
+ */
+function foo2() {
+	return match (random_bytes(1)) {
+		'a' => 'b',
+		default => throw new FooException(),
+	};
+}
+
+/**
+ * @throws FooException
+ */
+function foo3() {
+	$value = $nullableValue ?? throw new FooException();
+}
+
+/**
+ * @throws FooException
+ */
+function foo4() {
+	$value = $falsableValue ?: throw new FooException();
+}
+
+
+class FutureThrows
+{
+	private ?string $name;
+
+	/**
+	 * @throws FooException
+	 */
+	public function ok1(): string
+	{
+		return $this->name ?? throw new FooException();
+	}
+
+	/**
+	 * @throws FooException
+	 */
+	public function ok2(): string
+	{
+		return $this->name ?? $this->ok2();
+	}
+
+	/**
+	 * @throws FooException
+	 */
+	public function ok3(): string
+	{
+		return $this->name ?? throw FooException::create();
+	}
+
+	public function err(): string
+	{
+		return $this->name ?? throw new FooException(); // error: Missing @throws Pepakriz\PHPStanExceptionRules\Rules\ExpressionThrows\FooException annotation
+	}
+}


### PR DESCRIPTION
Add support for PHP 8 [Throw Expression](https://wiki.php.net/rfc/throw_expression)

Example:
```php
$value = $nullableValue ?? throw new InvalidArgumentException();
```